### PR TITLE
Auto refresh spotify tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Auto refresh spotify token
+
 ## [v1.0.0] - 2023-07-01
 
 ### Added

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use axum::{
-    debug_handler,
     extract::{Query, State},
     http::{Method, StatusCode},
     response::IntoResponse,

--- a/backend/src/spotify.rs
+++ b/backend/src/spotify.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use rspotify::{
     model::{ArtistId, IdError, PlaylistId, TrackId},
     prelude::BaseClient,
-    ClientCredsSpotify, ClientError, Credentials,
+    ClientCredsSpotify, ClientError, Config, Credentials,
 };
 use thiserror::Error;
 
@@ -27,8 +27,12 @@ pub struct SpotifyClient {
 impl SpotifyClient {
     pub async fn new(client_id: &str, client_secret: &str) -> SpotifyClient {
         let creds = Credentials::new(client_id, client_secret);
+        let config = Config {
+            token_refreshing: true,
+            ..Default::default()
+        };
 
-        let spotify = ClientCredsSpotify::new(creds);
+        let spotify = ClientCredsSpotify::with_config(creds, config);
 
         spotify.request_token().await.unwrap();
 


### PR DESCRIPTION
Spotify tokens weren't refreshed, causing the backend to fail. This should fix that, using rspotify's automatic token refreshing.
