### PR TITLE
Add /live and /ready endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.2 - 2023-08-08
+
+### Added
+
+- `/live` and `/ready` endpoints for Kubernetes integration ([#23](https://github.com/Petrosz007/wtf-i-like-this/pull/22))
+
+### Security
+
+- Bump word-wrap from 1.2.3 to 1.2.4 in /frontend ([#22](https://github.com/Petrosz007/wtf-i-like-this/pull/22))
+
+
 ## v1.0.1 - 2023-07-02
 
 ### Added

--- a/backend/src/spotify.rs
+++ b/backend/src/spotify.rs
@@ -39,6 +39,13 @@ impl SpotifyClient {
         SpotifyClient { spotify }
     }
 
+    /// Checks the readiness of the Spotify connection. If it returns Err there is an issue.
+    pub async fn check_readiness(&self) -> Result<(), MySpotifyError> {
+        self.spotify.refetch_token().await?;
+
+        Ok(())
+    }
+
     pub async fn genres_from_artist_id(
         &self,
         artist_id: ArtistId<'_>,


### PR DESCRIPTION
For better Kubernetes integation the `/live` and `/ready` endpoints can be used by Liveliness and Readiness probes
