### PR TITLE
Add multi-platform docker image building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,5 +64,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds multi-platform docker image building, so arm64 images are getting built as well. More info: https://docs.docker.com/build/ci/github-actions/multi-platform/
