### PR TITLE
Add spotify shortlink resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -37,28 +37,28 @@ jobs:
             type=sha
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.project }}
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,14 @@ jobs:
         working-directory: frontend
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '18'
           
       - name: Cache npm global modules (yarn)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-node-  
           
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -57,7 +57,7 @@ jobs:
         working-directory: backend
         
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "regex",
+ "reqwest",
  "rspotify",
  "rstest",
  "serde",
@@ -1114,9 +1115,9 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -2050,11 +2051,12 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -17,6 +17,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"]}
 tower-http = { version = "0.3.4", features = ["trace", "cors"] }
 tracing = "0.1.37"
 config = "0.13.3"
+reqwest = "0.11.20"
 
 [dev-dependencies]
 rstest = "0.17.0"

--- a/backend/src/url_parser.rs
+++ b/backend/src/url_parser.rs
@@ -1,11 +1,13 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
+use reqwest::Url;
 use rspotify::model::{PlaylistId, TrackId};
 
 #[derive(Debug, PartialEq)]
 pub enum UrlParseResult<'a> {
     SpotifyTrackId(TrackId<'a>),
     SpotifyPlaylistId(PlaylistId<'a>),
+    SpotifyShortLink(Url),
     ParseError,
 }
 
@@ -15,8 +17,11 @@ static SPOTIFY_TRACK_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new("/track/([a-zA-Z0-9]*)").unwrap());
 static SPOTIFY_PLAYLIST_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new("/playlist/([a-zA-Z0-9]*)").unwrap());
+static SPOTIFY_SHORT_LINK_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new("https://spotify.link/([a-zA-Z0-9]*)").unwrap());
 
-pub fn parse_url(url: &str) -> UrlParseResult {
+#[tracing::instrument]
+pub fn parse_url<'a, 'b>(url: &'a str) -> UrlParseResult<'b> {
     if let Some(captures) = SPOTIFY_TRACK_REGEX.captures(url) {
         let track_id = captures.get(1).unwrap().as_str().to_owned();
         match TrackId::from_id(track_id) {
@@ -27,6 +32,11 @@ pub fn parse_url(url: &str) -> UrlParseResult {
         let playlist_id = captures.get(1).unwrap().as_str().to_owned();
         match PlaylistId::from_id(playlist_id) {
             Ok(playlist_id) => SpotifyPlaylistId(playlist_id),
+            Err(_) => ParseError,
+        }
+    } else if SPOTIFY_SHORT_LINK_REGEX.is_match(url) {
+        match Url::parse(url) {
+            Ok(url) => SpotifyShortLink(url),
             Err(_) => ParseError,
         }
     } else {
@@ -42,6 +52,7 @@ mod test {
     #[rstest]
     #[case("https://open.spotify.com/playlist/3aH6s3vn4NKq3Hi3kUSz68?si=dd3bdff1b2ba4bd9", SpotifyPlaylistId(PlaylistId::from_id("3aH6s3vn4NKq3Hi3kUSz68").unwrap()))]
     #[case("https://open.spotify.com/track/2tzt6biW79znRmQCLBSWhG?si=0388bad880ec4a60", SpotifyTrackId(TrackId::from_id("2tzt6biW79znRmQCLBSWhG").unwrap()))]
+    #[case("https://spotify.link/N2zPz9qjoDb", SpotifyShortLink(Url::parse("https://spotify.link/N2zPz9qjoDb").unwrap()))]
     #[case(
         "https://open.spotify.com/something_garbage/2tzt6biW79znRmQCLBSWhG?si=0388bad880ec4a60",
         ParseError


### PR DESCRIPTION
Clicking Share on Spotify can now give a shortlink like https://spotify.link/N2zPz9qjoDb .

These links are simple HTTP redirects to the existing links like `https://open.spotify.com/track/...`. This PR adds this HTTP redirect resolution functionality.